### PR TITLE
package.json: standarize on test script on 'npm test'

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,4 +26,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run ci-test
+    - run: npm run test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,4 +26,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run test
+    - run: npm test

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,6 +11,6 @@ based on commits since the last active tag.
 
 ### Release an Update:
 
-1. Ensure all tests are passing `npm run ci-test`. The release scripts will not proceed
+1. Ensure all tests are passing `npm test`. The release scripts will not proceed
    if any test fails.
 2. Execute in your terminal: `npm run release`.

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "prettify": "npx prettier --write src test scripts",
     "build": "node scripts/build.js",
     "check-types": "tsc --noEmit --project tsconfig.json",
-    "pretest": "npm run build",
-    "test": "ava dist/test/**/test-*.js",
-    "ci-test": "npm run check-types && npm test",
+    "test": "npm run check-types && npm run unit",
+    "preunit": "npm run build",
+    "unit": "ava dist/test/**/test-*.js",
     "release": "np"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR switches from `npm run ci-test` to `npm test` which is a bit more standard. It also creates `npm run unit` which runs unit tests without running `tsc`.

cc @rcebulko, sorry for making you review this exact same change twice.