### PR TITLE
Handle ZERO_LENGTH nodes

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -19,6 +19,7 @@ import {isElementNode, NodeProto, TreeProto} from './ast.js';
 // See: https://github.com/microsoft/TypeScript/issues/27957
 // @ts-ignore
 import {createDocument} from '@ampproject/worker-dom/dist/server-lib.mjs';
+import {getTagId} from './htmltagenum.js';
 
 /**
  * @file Provides helpers for converting between Document and TreeProto formats.
@@ -47,6 +48,12 @@ export function fromTreeProtoHelper(
     const node = nodes[i];
     if (!isElementNode(node)) {
       parent.appendChild(doc.createTextNode(node.value));
+      continue;
+    }
+
+    // ZERO_LENGTH nodes get flattened into the parent.
+    if (node.tagid === getTagId('ZERO_LENGTH')) {
+      fromTreeProtoHelper(node.children, doc, parent);
       continue;
     }
 

--- a/test/test-dom.ts
+++ b/test/test-dom.ts
@@ -40,6 +40,31 @@ test('should handle empty ast in quirks mode', (t) => {
   t.is(printDoc(doc), '');
 });
 
+test('should handle tree under ZERO_LENGTH node', (t) => {
+  const ast: TreeProto = {
+    quirks_mode: true,
+    root: 0,
+    tree: [
+      {
+        tagid: getTagId('ZERO_LENGTH'),
+        value: undefined,
+        attributes: [],
+        children: [
+          {
+            value: 'html',
+            tagid: getTagId('html'),
+            attributes: [],
+            children: [],
+          },
+        ],
+      },
+    ],
+  };
+  const doc = fromTreeProto(ast);
+
+  t.is(printDoc(doc), '<html></html>');
+});
+
 test('should handle empty ast in strict mode', (t) => {
   const ast: TreeProto = {quirks_mode: false, tree: [], root: 0};
   const doc = fromTreeProto(ast);


### PR DESCRIPTION
**summary**
An unexpected part of the format is that our html asts begin with a `ZERO_LENGTH` node. Its purpose escapes me.
This nodetype throws within worker-dom since we are currently calling `doc.createElement(node.value)` and these node types have an undefined value. It appears that they function as a grouping device (almost like a parentheses) and should be  flattened into the parent.

**given html**
```html
<html><head></head><body></body></html>
```

**parsed output**
```js
{
  tree: [
    {
      tagid: 92,
      position: 0,
      end_position: 39,
      attributes: [],
      children: [
        {
          tagid: 43,
          value: "html",
          position: 0,
          end_position: 39,
          attributes: [],
          children: [
            {
              tagid: 41,
              value: "head",
              position: 6,
              end_position: 19,
              attributes: [],
              children: [],
            },
            {
              tagid: 13,
              value: "body",
              position: 19,
              end_position: 39,
              attributes: [],
              children: [],
            },
          ],
        },
      ],
    },
  ],
  root: 0,
  quirks_mode: true,
};
```