### PR TITLE
feature: configurable error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,7 @@ export interface InstructionMap {
 }
 
 function defaultHandleError(tagName, e: Error) {
-  const errorMsg =
-    `[bento-compiler]: Error thrown while rendering <${tagName}>\n` + e.stack;
-  throw new Error(errorMsg);
+  throw new Error(`[${tagName}]: ${e.stack}`);
 }
 
 export function renderAst(

--- a/test/html-utils.ts
+++ b/test/html-utils.ts
@@ -16,19 +16,12 @@
 import * as parse5 from 'parse5';
 import {getNumTerms, isElementNode, NodeProto, TreeProto} from '../src/ast.js';
 import {getTagId} from '../src/htmltagenum.js';
-import {renderAst, InstructionMap, Result} from '../src/index.js';
+import {renderAst, InstructionMap} from '../src/index.js';
 
-export function renderHtml(
-  html: string,
-  instructions: InstructionMap
-): Result<string> {
+export function renderHtml(html: string, instructions: InstructionMap): string {
   const tree = parse(html);
-  const result = renderAst(tree, instructions);
-
-  if (result.type === 'failure') {
-    return result;
-  }
-  return {type: 'success', value: print(result.value)};
+  const renderedAst = renderAst(tree, instructions);
+  return print(renderedAst);
 }
 
 export function parse(html: string): TreeProto {

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -84,7 +84,7 @@ test('should return the error if a single instruction throws', (t) => {
   t.throws(() => renderAst(ast, instructions), {message: /amp-fail/});
 });
 
-test('should return only the first error even if multiple would throw', (t) => {
+test('should only throw the first error even if multiple would throw', (t) => {
   const instructions = {
     'amp-success': (el: Element) => {
       el.setAttribute('rendered', '');
@@ -98,9 +98,9 @@ test('should return only the first error even if multiple would throw', (t) => {
   };
 
   const ast = treeProto(
-    h('amp-success', {}, [h('amp-fail1'), h('amp-fail1'), h('amp-fail2')])
+    h('amp-success', {}, [h('amp-fail1'), h('amp-fail2'), h('amp-fail2')])
   );
-  t.throws(() => renderAst(ast, instructions), {message: /amp-fail/});
+  t.throws(() => renderAst(ast, instructions), {message: /amp-fail1/});
 });
 
 test('should allow a custom error handler', (t) => {

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -81,7 +81,7 @@ test('should render provided instruction', (t) => {
   t.deepEqual(renderAst(ast, instructions), expected);
 });
 
-test('should return the collection of found errors if a single instruction throws', (t) => {
+test('should return the error if a single instruction throws', (t) => {
   const instructions = {
     'amp-fail': (_el: Element) => {
       throw new Error('Cannot render <amp-fail>');
@@ -96,7 +96,7 @@ test('should return the collection of found errors if a single instruction throw
   t.deepEqual(renderAst(ast, instructions), expected);
 });
 
-test('should return the collection of found errors if an instruction throws', (t) => {
+test('should return only the first error even if multiple would throw', (t) => {
   const instructions = {
     'amp-success': (el: Element) => {
       el.setAttribute('rendered', '');
@@ -114,10 +114,7 @@ test('should return the collection of found errors if an instruction throws', (t
   );
   const expected: Result<string> = {
     type: 'failure',
-    error: new Map([
-      ['amp-fail1', ['Cannot render <amp-fail1>', 'Cannot render <amp-fail1>']],
-      ['amp-fail2', ['Cannot render <amp-fail2>']],
-    ]),
+    error: new Map([['amp-fail1', ['Cannot render <amp-fail1>']]]),
   };
   t.deepEqual(renderAst(ast, instructions), expected);
 });


### PR DESCRIPTION
**summary**
Based on feedback from @rcebulko, we'd prefer to fail-fast rather than collect all errors.
This PR creates allow for an optional error handler that defaults to throwing -- that way the consumer can decide whether to collect or early-exit