### PR TITLE
ZERO_LENGTH corresponds to #document

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -55,7 +55,7 @@ export function fromDocument(doc: Document): TreeProto {
   const children = Array.from(doc.childNodes).map(mapDomNodeToNodeProto);
   return {
     quirks_mode: doc.compatMode === 'BackCompat',
-    tree: [getDocumentNode(children)],
+    tree: [{tagid: 92, children}],
     root: 0,
   };
 }
@@ -90,8 +90,4 @@ function mapDomNodeToNodeProto(node: Node): NodeProto {
 const termRegex = /[\w-]+/gm;
 export function getNumTerms(str: string): number {
   return str.match(termRegex)?.length ?? 0;
-}
-
-export function getDocumentNode(children = []): DocumentNodeProto {
-  return {tagid: 92, children};
 }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -48,7 +48,7 @@ export interface AttributeProto {
 }
 
 export function isElementNode(node: NodeProto): node is ElementNodeProto {
-  return 'tagid' in node;
+  return (node as any).tagid !== undefined;
 }
 
 export function fromDocument(doc: Document): TreeProto {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -20,7 +20,7 @@ import {getTagId} from './htmltagenum.js';
  */
 
 export interface TreeProto {
-  tree: Array<NodeProto>;
+  tree: [DocumentNodeProto];
   quirks_mode: undefined | boolean;
   root: number;
 }
@@ -36,6 +36,11 @@ export interface ElementNodeProto {
   children: Array<NodeProto>;
 }
 
+export interface DocumentNodeProto {
+  tagid: 92; // See htmltagenum.ts
+  children: Array<NodeProto>;
+}
+
 export type NodeProto = TextNodeProto | ElementNodeProto;
 export interface AttributeProto {
   name: string;
@@ -47,9 +52,10 @@ export function isElementNode(node: NodeProto): node is ElementNodeProto {
 }
 
 export function fromDocument(doc: Document): TreeProto {
+  const children = Array.from(doc.childNodes).map(mapDomNodeToNodeProto);
   return {
     quirks_mode: doc.compatMode === 'BackCompat',
-    tree: Array.from(doc.childNodes).map(mapDomNodeToNodeProto),
+    tree: [getDocumentNode(children)],
     root: 0,
   };
 }
@@ -84,4 +90,8 @@ function mapDomNodeToNodeProto(node: Node): NodeProto {
 const termRegex = /[\w-]+/gm;
 export function getNumTerms(str: string): number {
   return str.match(termRegex)?.length ?? 0;
+}
+
+export function getDocumentNode(children = []): DocumentNodeProto {
+  return {tagid: 92, children};
 }

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -35,10 +35,10 @@ export function fromTreeProto(ast: TreeProto) {
     },
   });
 
-  if (ast.tree[0]?.tagid !== getTagId('ZERO_LENGTH')) {
-    const firstNode = ast.tree?.[0]?.tagid;
+  const firstNodeTagId = ast.tree?.[0]?.tagid;
+  if (firstNodeTagId !== getTagId('ZERO_LENGTH')) {
     throw new Error(
-      `HTML must begin with a #document tag, found: ${firstNode}`
+      `HTML must begin with a #document tag, found: ${firstNodeTagId}`
     );
   }
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -35,7 +35,14 @@ export function fromTreeProto(ast: TreeProto) {
     },
   });
 
-  fromTreeProtoHelper(ast.tree, doc, doc);
+  if (ast.tree[0]?.tagid !== getTagId('ZERO_LENGTH')) {
+    const firstNode = ast.tree?.[0]?.tagid;
+    throw new Error(
+      `HTML must begin with a #document tag, found: ${firstNode}`
+    );
+  }
+
+  fromTreeProtoHelper(ast.tree[0].children, doc, doc);
   return doc;
 }
 
@@ -51,10 +58,8 @@ export function fromTreeProtoHelper(
       continue;
     }
 
-    // ZERO_LENGTH nodes get flattened into the parent.
     if (node.tagid === getTagId('ZERO_LENGTH')) {
-      fromTreeProtoHelper(node.children, doc, parent);
-      continue;
+      throw new Error(`Found a #document in a non-root position`);
     }
 
     const domNode = doc.createElement(node.value);

--- a/src/htmltagenum.ts
+++ b/src/htmltagenum.ts
@@ -96,7 +96,7 @@ const mapping = {
   U: 89,
   UL: 90,
   VAR: 91,
-  // Empty tag
+  // Corresponds to #document
   ZERO_LENGTH: 92,
   // Used in repository/lexer/html_lexer.cc
   BANG_DASH_DASH: 93,

--- a/test/html-utils.ts
+++ b/test/html-utils.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 import * as parse5 from 'parse5';
-import {getNumTerms, isElementNode, NodeProto, TreeProto} from '../src/ast.js';
+import {
+  DocumentNodeProto,
+  getDocumentNode,
+  getNumTerms,
+  isElementNode,
+  NodeProto,
+  TreeProto,
+} from '../src/ast.js';
 import {getTagId} from '../src/htmltagenum.js';
 import {renderAst, InstructionMap} from '../src/index.js';
 
@@ -33,9 +40,10 @@ export function parse(html: string): TreeProto {
  */
 function fromParse5Document(doc: parse5.Document): TreeProto {
   const quirksMode = doc.mode === 'quirks';
-  const tree = (doc.childNodes ?? [])
+  const children = (doc.childNodes ?? [])
     .filter(isInParseTree)
     .map(mapParse5NodeToNodeProto);
+  const tree: [DocumentNodeProto] = [getDocumentNode(children)];
 
   return {quirks_mode: quirksMode, tree, root: 0};
 
@@ -74,7 +82,7 @@ function fromParse5Document(doc: parse5.Document): TreeProto {
 
 export function print(ast: TreeProto): string {
   const doctypePrefix = ast.quirks_mode ? '' : '<!DOCTYPE html>';
-  const printedTree = ast.tree.map(printNode).join('');
+  const printedTree = ast.tree[0].children.map(printNode).join('');
   return doctypePrefix + printedTree;
 }
 

--- a/test/html-utils.ts
+++ b/test/html-utils.ts
@@ -16,7 +16,6 @@
 import * as parse5 from 'parse5';
 import {
   DocumentNodeProto,
-  getDocumentNode,
   getNumTerms,
   isElementNode,
   NodeProto,
@@ -43,7 +42,7 @@ function fromParse5Document(doc: parse5.Document): TreeProto {
   const children = (doc.childNodes ?? [])
     .filter(isInParseTree)
     .map(mapParse5NodeToNodeProto);
-  const tree: [DocumentNodeProto] = [getDocumentNode(children)];
+  const tree: [DocumentNodeProto] = [{tagid: 92, children}];
 
   return {quirks_mode: quirksMode, tree, root: 0};
 

--- a/test/test-dom.ts
+++ b/test/test-dom.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {getDocumentNode, NodeProto, TreeProto} from '../src/ast.js';
+import {DocumentNodeProto, NodeProto, TreeProto} from '../src/ast.js';
 
 import test from 'ava';
 import {fromTreeProto} from '../src/dom.js';
@@ -31,6 +31,10 @@ function parseDoc(html: string): Document {
 
 function htmlWithBody(html: string) {
   return `<html><head></head><body>${html}</body></html>`;
+}
+
+function getDocumentNode(children = []): DocumentNodeProto {
+  return {tagid: 92, children};
 }
 
 test('should handle empty ast in quirks mode', (t) => {

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import test from 'ava';
-import {getDocumentNode, NodeProto, TreeProto} from '../src/ast.js';
+import {DocumentNodeProto, NodeProto, TreeProto} from '../src/ast.js';
 import {getTagId} from '../src/htmltagenum.js';
 import {renderAst} from '../src/index.js';
 
@@ -49,7 +49,7 @@ function treeProto(
   tree: NodeProto[] | NodeProto = [],
   {quirks_mode, root} = {quirks_mode: false, root: 0}
 ): TreeProto {
-  return {tree: [getDocumentNode([].concat(tree))], quirks_mode, root};
+  return {tree: [{tagid: 92, children: [].concat(tree)}], quirks_mode, root};
 }
 
 test('should have no effect with empty instructions', (t) => {
@@ -156,10 +156,11 @@ test('should not render elements within templates', (t) => {
 });
 
 test('should conserve quirks_mode and root', (t) => {
-  let ast: TreeProto = {root: 42, quirks_mode: true, tree: [getDocumentNode()]};
+  const tree: [DocumentNodeProto] = [{tagid: 92, children: []}];
+  let ast: TreeProto = {root: 42, quirks_mode: true, tree};
   t.deepEqual(renderAst(ast, {}), ast);
 
-  ast = {root: 7, quirks_mode: false, tree: [getDocumentNode()]};
+  ast = {root: 7, quirks_mode: false, tree};
   t.deepEqual(renderAst(ast, {}), ast);
 });
 

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import test from 'ava';
-import {NodeProto, TreeProto} from '../src/ast.js';
+import {getDocumentNode, NodeProto, TreeProto} from '../src/ast.js';
 import {getTagId} from '../src/htmltagenum.js';
 import {renderAst} from '../src/index.js';
 
@@ -48,8 +48,8 @@ function h(
 function treeProto(
   tree: NodeProto[] | NodeProto = [],
   {quirks_mode, root} = {quirks_mode: false, root: 0}
-) {
-  return {tree: [].concat(tree), quirks_mode, root};
+): TreeProto {
+  return {tree: [getDocumentNode([].concat(tree))], quirks_mode, root};
 }
 
 test('should have no effect with empty instructions', (t) => {
@@ -156,10 +156,10 @@ test('should not render elements within templates', (t) => {
 });
 
 test('should conserve quirks_mode and root', (t) => {
-  let ast: TreeProto = {root: 42, quirks_mode: true, tree: []};
+  let ast: TreeProto = {root: 42, quirks_mode: true, tree: [getDocumentNode()]};
   t.deepEqual(renderAst(ast, {}), ast);
 
-  ast = {root: 7, quirks_mode: false, tree: []};
+  ast = {root: 7, quirks_mode: false, tree: [getDocumentNode()]};
   t.deepEqual(renderAst(ast, {}), ast);
 });
 
@@ -177,7 +177,7 @@ test('should set tagids of element nodes', (t) => {
     renderedAst,
     treeProto([h('amp-list', {}, [h('b', {}, ['bolded text'])])])
   );
-  t.is(renderedAst.tree[0]?.['children']?.[0]?.tagid, 7);
+  t.is(renderedAst.tree[0].children[0]['children']?.[0]?.tagid, getTagId('b'));
 });
 
 // TODO: ensure it is ok for our num_terms to be inaccurate.
@@ -196,6 +196,6 @@ test('should set num_terms of text nodes', (t) => {
     result,
     treeProto([h('amp-list', {}, ['element text', 'hello\ttabby\ttext'])])
   );
-  t.is(result.tree[0]?.['children']?.[0]?.num_terms, 2);
-  t.is(result.tree[0]?.['children']?.[1]?.num_terms, 3);
+  t.is(result.tree[0].children[0]?.['children']?.[0]?.num_terms, 2);
+  t.is(result.tree[0].children[0]?.['children']?.[1]?.num_terms, 3);
 });


### PR DESCRIPTION
**summary**
Joke is on me for merging https://github.com/ampproject/bento-compiler/pull/17#issue-728965949 without fully understanding what `ZERO_LENGTH` meant. It corresponds to `#document`. Therefore simply flattening and dropping is not okay, as we need to retain the node.

**testing done**
E2E tested via hosted compiler backend