### PR TITLE
Create benchmarking script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -481,6 +481,16 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -3407,6 +3417,12 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
     },
     "plur": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   },
   "scripts": {
     "prettify": "npx prettier --write src test scripts",
+    "prebench": "npm run build",
+    "bench": "node scripts/benchmark.js",
     "build": "node scripts/build.js",
     "check-types": "tsc --noEmit --project tsconfig.json",
     "test": "npm run check-types && npm run unit",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@types/parse5": "6.0.1",
     "ava": "3.15.0",
+    "benchmark": "^2.1.4",
     "esbuild": "0.12.28",
     "globby": "12.0.2",
     "np": "7.5.0",

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -1,0 +1,41 @@
+import {renderAst} from '../dist/src/index.js';
+import {parse} from '../dist/test/html-utils.js';
+
+const sum = (numList) => numList.reduce((a, b) => a + b, 0);
+const mean = (numList) => sum(numList) / numList.length;
+
+function getHtmlNodes(n) {
+  let nodes = '';
+  for (let i = 0; i < n; i++) {
+    nodes += `<bento-node></bento-node>`;
+  }
+  return nodes;
+}
+
+function measureRender(name, doc) {
+  const fakeBuildDom = (el) => el.setAttribute('rendered');
+  // First do baseline iteration measure
+  let measures = [];
+  for (let i = 0; i < 100; i++) {
+    let startTime = Date.now();
+    renderAst(doc, {});
+    measures.push(Date.now() - startTime);
+  }
+  console.log(`${name} noop avg: ${mean(measures)}`);
+
+  // Then do a worst-case scenario every node must be measured
+  measures = [];
+  for (let i = 0; i < 1000; i++) {
+    let startTime = Date.now();
+    renderAst(doc, {'bento-component': fakeBuildDom});
+    measures.push(Date.now() - startTime);
+  }
+  console.log(`${name} render avg: ${mean(measures)}ms`);
+}
+
+for (let i = 1; i <= 10000; i *= 10) {
+  const doc = parse(
+    `<html><head></head><body>${getHtmlNodes(i)}</body></html>`
+  );
+  measureRender(`Document: ${i} nodes`, doc);
+}

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -34,6 +34,6 @@ suite
   // })
   .on('complete', function () {
     const results = Array.from(this);
-    console.log(results.map((r) => r.toString()).join('\n'));
+    console.log(results.join('\n'));
   })
   .run();

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -12,6 +12,7 @@ const doc1 = getDoc(1);
 const doc10 = getDoc(10);
 const doc100 = getDoc(100);
 const doc1000 = getDoc(1000);
+const doc10000 = getDoc(10000);
 
 var suite = new Benchmark.Suite();
 suite
@@ -27,6 +28,10 @@ suite
   .add('Document: 1000 nodes', function () {
     renderAst(doc1000, {});
   })
+  // TODO: uncomment when this doesn't crash.
+  // .add('Document: 10000 nodes', function () {
+  //   renderAst(doc10000, {});
+  // })
   .on('complete', function () {
     const results = Array.from(this);
     console.log(results.map((r) => r.toString()).join('\n'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,9 +30,7 @@ export function renderAst(
   instructions: InstructionMap,
   {handleError = defaultHandleError} = {}
 ): TreeProto {
-  let start = Date.now();
   const doc = dom.fromTreeProto(tree);
-  console.log(`Done creating worker-dom: ${Date.now() - start}ms`);
 
   // TODO: Optimization opportunity by writing a custom walk instead of N querySelectorAll.
   for (let [tagName, buildDom] of Object.entries(instructions)) {
@@ -51,9 +49,7 @@ export function renderAst(
     }
   }
 
-  start = Date.now();
   const transformedAst = ast.fromDocument(doc);
-  console.log(`Done creating AST: ${Date.now() - start}ms`);
   transformedAst.root = tree.root;
   transformedAst.quirks_mode = tree.quirks_mode;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,9 @@ export function renderAst(
   instructions: InstructionMap,
   {handleError = defaultHandleError} = {}
 ): TreeProto {
+  let start = Date.now();
   const doc = dom.fromTreeProto(tree);
+  console.log(`Done creating worker-dom: ${Date.now() - start}ms`);
 
   // TODO: Optimization opportunity by writing a custom walk instead of N querySelectorAll.
   for (let [tagName, buildDom] of Object.entries(instructions)) {
@@ -49,7 +51,9 @@ export function renderAst(
     }
   }
 
+  start = Date.now();
   const transformedAst = ast.fromDocument(doc);
+  console.log(`Done creating AST: ${Date.now() - start}ms`);
   transformedAst.root = tree.root;
   transformedAst.quirks_mode = tree.quirks_mode;
 


### PR DESCRIPTION
**summary**
Creates simple benchmarking script using `benchmark.js`.
Thank you @rcebulko for pushing for this, as it has been enlightening.

We need to speed this up and remove the mem leak for server-lib.mjs.
This should scale linearly, but I bet doesn't right now due to GC thrashing.

**results**
```
Document: 1 node x 31,722 ops/sec ±4.79% (69 runs sampled)
Document: 10 nodes x 9,072 ops/sec ±9.14% (73 runs sampled)
Document: 100 nodes x 753 ops/sec ±26.13% (34 runs sampled)
Document: 1000 nodes x 7.57 ops/sec ±7.32% (24 runs sampled)

// Crashes for 10000 nodes
```