### PR TITLE
update worker-dom, uncomment benchmark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ampproject/worker-dom": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.32.0.tgz",
-      "integrity": "sha512-ReUUeX/MDMXAK5RjmfiZgGXcbNyzqrKGV3HwREbeqOQmq7oD+ThzkMt9YyuoModgdi+d9x/G/h7pARGavOh9Dg=="
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.32.1.tgz",
+      "integrity": "sha512-O8AfOnBPJc6Go+U8c+mCJbQzL9eMExlz7kR25E/oaPd+P0BuPGefeLbgdzEsIzS/iovpgpyCDZLwDQ1LZSfw9w=="
     },
     "@babel/code-frame": {
       "version": "7.14.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ampproject/worker-dom": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.31.0.tgz",
-      "integrity": "sha512-/zzLEv+EpVoOfK2eRYAEn+GLOCB2O3vR9CEH6cXec3Jasnn0Ci/vuD0lGSdcVGlMMk7tYodc1WNw1P9R5yCM0Q=="
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.32.0.tgz",
+      "integrity": "sha512-ReUUeX/MDMXAK5RjmfiZgGXcbNyzqrKGV3HwREbeqOQmq7oD+ThzkMt9YyuoModgdi+d9x/G/h7pARGavOh9Dg=="
     },
     "@babel/code-frame": {
       "version": "7.14.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@ampproject/worker-dom": "0.32.0"
+    "@ampproject/worker-dom": "0.32.1"
   },
   "np": {
     "branch": "main",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "4.4.3"
   },
   "dependencies": {
-    "@ampproject/worker-dom": "0.31.0"
+    "@ampproject/worker-dom": "0.32.0"
   },
   "np": {
     "branch": "main",

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -28,10 +28,9 @@ suite
   .add('Document: 1000 nodes', function () {
     renderAst(doc1000, {});
   })
-  // TODO: uncomment when this doesn't crash.
-  // .add('Document: 10000 nodes', function () {
-  //   renderAst(doc10000, {});
-  // })
+  .add('Document: 10000 nodes', function () {
+    renderAst(doc10000, {});
+  })
   .on('complete', function () {
     const results = Array.from(this);
     console.log(results.join('\n'));

--- a/scripts/benchmark.js
+++ b/scripts/benchmark.js
@@ -13,6 +13,7 @@ const doc10 = getDoc(10);
 const doc100 = getDoc(100);
 const doc1000 = getDoc(1000);
 const doc10000 = getDoc(10000);
+const doc100000 = getDoc(100000);
 
 var suite = new Benchmark.Suite();
 suite
@@ -30,6 +31,9 @@ suite
   })
   .add('Document: 10000 nodes', function () {
     renderAst(doc10000, {});
+  })
+  .add('Document: 100000 nodes', function () {
+    renderAst(doc100000, {});
   })
   .on('complete', function () {
     const results = Array.from(this);


### PR DESCRIPTION
**summary**
Bumps `worker-dom` from 0.31 to 0.32.1, which includes performance improvements to `document.createElement`.
Results are 65x faster compilation for normal sized documents (1000 nodes) 🎉  🚀 .

before
```
Document: 1 node x 31,867 ops/sec ±4.42% (69 runs sampled)
Document: 10 nodes x 8,943 ops/sec ±9.14% (71 runs sampled)
Document: 100 nodes x 640 ops/sec ±45.72% (35 runs sampled)
Document: 1000 nodes x 8.17 ops/sec ±5.72% (25 runs sampled)
# Crashes after this
```

after
```
Document: 1 node x 98,487 ops/sec ±1.45% (92 runs sampled)
Document: 10 nodes x 38,525 ops/sec ±0.98% (86 runs sampled)
Document: 100 nodes x 5,265 ops/sec ±1.78% (92 runs sampled)
Document: 1000 nodes x 522 ops/sec ±1.29% (88 runs sampled)
Document: 10000 nodes x 27.18 ops/sec ±2.06% (48 runs sampled)
Document: 100000 nodes x 2.88 ops/sec ±3.71% (12 runs sampled)
```