### PR TITLE
skip nodes with script parents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ function renderNodeDeep(
     const elements = Array.from(node.querySelectorAll(tagName));
     for (const element of elements) {
       // Do not render anything inside of templates.
-      if (isInTemplate(element)) {
+      if (isInTemplateOrScript(element)) {
         continue;
       }
 
@@ -85,9 +85,12 @@ function renderNodeDeep(
   }
 }
 
-function isInTemplate(node: Node) {
+function isInTemplateOrScript(node: Node) {
   while (node.parentNode) {
-    if (node.parentNode.nodeName === 'TEMPLATE') {
+    if (
+      node.parentNode.nodeName === 'TEMPLATE' ||
+      node.parentNode.nodeName === 'SCRIPT'
+    ) {
       return true;
     }
     node = node.parentNode;

--- a/test/test-index.ts
+++ b/test/test-index.ts
@@ -142,16 +142,19 @@ test('should be unaffected by async modifications', async (t) => {
   t.deepEqual(rendered, ast);
 });
 
-test('should not render elements within templates', (t) => {
+test('should not render elements within templates or scripts', (t) => {
   const instructions = {
     'amp-element': () => {
       throw new Error('Should not be called');
     },
   };
 
-  const ast = treeProto(h('template', {}, [h('amp-element')]));
-  const rendered = renderAstDocument(ast, instructions);
+  let ast = treeProto(h('template', {}, [h('amp-element')]));
+  let rendered = renderAstDocument(ast, instructions);
+  t.deepEqual(rendered, ast);
 
+  ast = treeProto(h('script', {type: 'template'}, [h('amp-element')]));
+  rendered = renderAstDocument(ast, instructions);
   t.deepEqual(rendered, ast);
 });
 


### PR DESCRIPTION
**summary**

BC Must not render tags within either `<template>` or `<script>` elements. We were already skipping `template`, this PR adds `script`.