### PR TITLE
Fix boolean attribute hadling s.t. it doesnt have 'undefined' value

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -45,15 +45,25 @@ export function fromNode(node: Node): NodeProto {
   }
 
   const elementNode = node as Element;
-  const attributes = Array.from(elementNode.attributes).map(
-    ({name, value}) => ({name, value})
-  );
-  return {
+  const protoNode: NodeProto = {
     tagid: getTagId(elementNode.tagName),
     value: elementNode.tagName.toLowerCase(),
-    attributes,
-    children: Array.from(node.childNodes).map(fromNode),
   };
+
+  if (elementNode.attributes?.length) {
+    protoNode.attributes = Array.from(elementNode.attributes).map(
+      ({name, value}) => {
+        if (value === '') {
+          return {name};
+        }
+        return {name, value};
+      }
+    );
+  }
+  if (node.childNodes?.length) {
+    protoNode.children = Array.from(node.childNodes).map(fromNode);
+  }
+  return protoNode;
 }
 
 const termRegex = /[\w-]+/gm;

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -70,11 +70,19 @@ function fromTreeProtoHelper(nodes: NodeProto[], doc: Document, parent: Node) {
     }
 
     const domNode = doc.createElement(node.value);
-    for (const {name, value} of node.attributes) {
-      domNode.setAttribute(name, value);
+    if (node.attributes) {
+      for (const {name, value} of node.attributes) {
+        if (typeof value === 'undefined') {
+          domNode.setAttribute(name, '');
+        } else {
+          domNode.setAttribute(name, value);
+        }
+      }
     }
     parent.appendChild(domNode);
 
-    fromTreeProtoHelper(node.children, doc, domNode);
+    if (node.children) {
+      fromTreeProtoHelper(node.children, doc, domNode);
+    }
   }
 }

--- a/src/protos.ts
+++ b/src/protos.ts
@@ -19,8 +19,8 @@ export interface TextNodeProto {
 export interface ElementNodeProto {
   tagid: number;
   value: string;
-  attributes: Array<AttributeProto>;
-  children: Array<NodeProto>;
+  attributes?: Array<AttributeProto>;
+  children?: Array<NodeProto>;
 }
 
 export interface AttributeProto {


### PR DESCRIPTION
**previous input**
```
<html amp></html>
```
**output**
```
<html amp=undefined></html>
```
**new output**
```
<html amp></html>
```

While there I also updated handling of children/attributes to allow them to be empty. This improves efficiency over the wire. It also simplifies testing there is no accidental diff between AMP HTML C++ parse and what we send back.